### PR TITLE
Fix. Call centralClick callback when clicking central bubble.

### DIFF
--- a/src/plugins/central-click/central-click.js
+++ b/src/plugins/central-click/central-click.js
@@ -9,8 +9,13 @@ d3.svg.BubbleChart.define("central-click", function (options) {
     return function (node) {
       var fn = original.apply(this, arguments);
       self.event.on("click", function(node) {
-        if (node.selectAll("text.central-click")[0].length === 1) {
-          alert("Hello there!\nCentral bubble is clicked.");
+        if (node.selectAll("text.central-click")[0].length === 1
+            && options.centralClick
+            && node.datum) {
+          var nodeDatum = node.datum();
+          if (nodeDatum.item) {
+            options.centralClick(node.datum().item);
+          }
         }
       });
       return fn;

--- a/src/plugins/central-click/central-click.js
+++ b/src/plugins/central-click/central-click.js
@@ -14,7 +14,7 @@ d3.svg.BubbleChart.define("central-click", function (options) {
             && node.datum) {
           var nodeDatum = node.datum();
           if (nodeDatum.item) {
-            options.centralClick(node.datum().item);
+            options.centralClick(nodeDatum.item);
           }
         }
       });

--- a/test/test-bubble-chart.html
+++ b/test/test-bubble-chart.html
@@ -9,7 +9,7 @@
   <script src="../bower_components/jquery/dist/jquery.min.js"></script>
   <script src="../bower_components/d3/d3.min.js"></script>
   <script src="../bower_components/d3-transform/src/d3-transform.js"></script>
-  <script src="../bower_components/cafej/src/extarray.js"></script>
+  <script src="../bower_components/cafej/src/ext-array.js"></script>
   <script src="../bower_components/cafej/src/misc.js"></script>
   <script src="../bower_components/cafej/src/micro-observer.js"></script>
   <script src="../bower_components/microplugin/src/microplugin.js"></script>

--- a/test/test-bubble-chart.js
+++ b/test/test-bubble-chart.js
@@ -40,8 +40,8 @@ $(document).ready(function () {
             "fill": "white"
           },
           attr: {dy: "65px"},
-          centralClick: function() {
-            alert("Here is more details!!");
+          centralClick: function(item) {
+            alert("Here is more details: " + item.text + "!!");
           }
         }
       },


### PR DESCRIPTION
The centralClick callback given in the options object to the central-click plugin was never called when clicking the central bubble.
